### PR TITLE
Fix `push_front`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ Array- and slice-backed double-ended queues in 100% safe Rust.
 This crate provides `ArrayDeque` and `SliceDeque`, fixed-size ring buffers with
 interfaces similar to the standard library's `VecDeque`.
 
-`holodeque` makes use of the unstable `array_map` feature to provide `Default`
-initialization of arbitrarily-sized arrays. As a result, **a `nightly` compiler
-is required until this feature is stabilized**. See the [tracking issue] for its
-current status.
-
-[tracking issue]: https://github.com/rust-lang/rust/issues/75243
-
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,7 @@
 //! This crate provides [`ArrayDeque`] and [`SliceDeque`], fixed-size ring
 //! buffers with interfaces similar to the standard library's [`VecDeque`].
 //!
-//! `holodeque` makes use of the unstable [`array_map`] feature to provide
-//! `Default` initialization of arbitrarily-sized arrays. As a result, **a
-//! `nightly` compiler is required until this feature is stabilized**. See the
-//! [tracking issue] for its current status.
-//!
 //! [`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
-//! [`array_map`]: https://doc.rust-lang.org/unstable-book/library-features/array-map.html
-//! [tracking issue]: https://github.com/rust-lang/rust/issues/75243
 //!
 //! # Example
 //!
@@ -84,7 +77,6 @@
 //! [`MaybeUninit`]: https://doc.rust-lang.org/core/mem/union.MaybeUninit.html
 //! [`tinyvec`]: https://docs.rs/tinyvec
 
-#![feature(array_map)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -140,7 +140,7 @@ pub trait Meta: Clone + Sized {
 
             MetaLayout::Linear { first: 0, len } => {
                 self.set_layout(MetaLayout::Wrapped {
-                    wrap_len: NonZeroUsize::new(1).unwrap(),
+                    wrap_len: len,
                     gap_len: self.capacity() - (len.get() + 1),
                 });
 

--- a/src/slice_deque.rs
+++ b/src/slice_deque.rs
@@ -1089,6 +1089,32 @@ mod tests {
     }
 
     #[test]
+    fn push_front_becomes_wrapped() {
+        let mut slice = [0u32, 0, 0];
+        let mut deque = SliceDeque::new_in(&mut slice);
+
+        deque.push_back(42).unwrap();
+        deque.push_back(73).unwrap();
+        deque.push_front(37).unwrap();
+
+        assert_eq!(deque.front(), Some(&37));
+        assert_eq!(deque.back(), Some(&73));
+    }
+
+    #[test]
+    fn push_back_becomes_wrapped() {
+        let mut slice = [0u32, 0, 0];
+        let mut deque = SliceDeque::new_in(&mut slice);
+
+        deque.push_front(42).unwrap();
+        deque.push_front(73).unwrap();
+        deque.push_back(37).unwrap();
+
+        assert_eq!(deque.front(), Some(&73));
+        assert_eq!(deque.back(), Some(&37));
+    }
+
+    #[test]
     fn push_both_ends_front_back() {
         let mut slice = ["", "", ""];
         let mut deque = SliceDeque::new_in(&mut slice);


### PR DESCRIPTION
This fixes pushing to the front when linear becomes wrapping, see the newly added test `push_front_becomes_wrapped` which would fail without this fix. Now `push_front` behaves like `VecDeque`. Also the feature `array_map` has been stabilized and it compiles on stable, so I removed all mentions of that feature.