### PR TITLE
`array_map` features is on stable rust:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ categories = ["data-structures", "no-std"]
 documentation = "https://docs.rs/holodeque"
 repository = "https://github.com/dataphract/holodeque"
 readme = "README.md"
-version = "0.2.0" # if changed, html_root_url must also be changed!
+version = "0.2.1" # if changed, html_root_url must also be changed!
 edition = "2018"
+
+rust_version = "1.55.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ Array- and slice-backed double-ended queues in 100% safe Rust.
 This crate provides `ArrayDeque` and `SliceDeque`, fixed-size ring buffers with
 interfaces similar to the standard library's `VecDeque`.
 
-`holodeque` makes use of the unstable `array_map` feature to provide `Default`
-initialization of arbitrarily-sized arrays. As a result, **a `nightly` compiler
-is required until this feature is stabilized**. See the [tracking issue] for its
-current status.
-
-[tracking issue]: https://github.com/rust-lang/rust/issues/75243
-
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,6 @@
 //! This crate provides [`ArrayDeque`] and [`SliceDeque`], fixed-size ring
 //! buffers with interfaces similar to the standard library's [`VecDeque`].
 //!
-//! `holodeque` makes use of the unstable [`array_map`] feature to provide
-//! `Default` initialization of arbitrarily-sized arrays. As a result, **a
-//! `nightly` compiler is required until this feature is stabilized**. See the
-//! [tracking issue] for its current status.
-//!
 //! [`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
 //! [`array_map`]: https://doc.rust-lang.org/unstable-book/library-features/array-map.html
 //! [tracking issue]: https://github.com/rust-lang/rust/issues/75243
@@ -84,11 +79,10 @@
 //! [`MaybeUninit`]: https://doc.rust-lang.org/core/mem/union.MaybeUninit.html
 //! [`tinyvec`]: https://docs.rs/tinyvec
 
-#![feature(array_map)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![doc(html_root_url = "https://docs.rs/holodeque/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/holodeque/0.2.1")]
 
 pub mod array_deque;
 mod meta;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! buffers with interfaces similar to the standard library's [`VecDeque`].
 //!
 //! [`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
-//! [`array_map`]: https://doc.rust-lang.org/unstable-book/library-features/array-map.html
-//! [tracking issue]: https://github.com/rust-lang/rust/issues/75243
 //!
 //! # Example
 //!


### PR DESCRIPTION
- Cargo - add rust_version to 1.55
- lib - Remove doc comment for stabilization

It would be nice to also:
1. Update Rust edition to 2021
2. Remove the HTML check for docs:
  `#![doc(html_root_url = "https://docs.rs/holodeque/0.2.1")]`
  To my knowledge we can just use:
  `#![doc(html_root_url = "https://docs.rs/holodeque")]`